### PR TITLE
Don't paginate smaller datasets.

### DIFF
--- a/tests/test_store_mongodb.py
+++ b/tests/test_store_mongodb.py
@@ -100,16 +100,17 @@ def test_find():
     meta, things = store.find()
     assert meta['total'] == 4
     assert meta['page'] == 1
-    assert meta['pages'] == 1
+    assert meta['pages'] == 0
     assert len(things) == 4
 
-    meta, things = store.find(page_size=2)
+    meta, things = store.find(page_size=2, paginate_if_longer_than=2)
     assert meta['page'] == 1
     assert meta['pages'] == 2
     assert len(things) == 2
 
-    meta, things = store.find(page=2, page_size=2)
+    meta, things = store.find(page=2, page_size=2, paginate_if_longer_than=2)
     assert meta['page'] == 2
     assert meta['pages'] == 2
     assert len(things) == 2
+
     clear_db(mongo_uri, store.db.name)

--- a/thingstance/stores/mongodb.py
+++ b/thingstance/stores/mongodb.py
@@ -33,9 +33,15 @@ class MongoStore(Store):
         thing.primitive = doc
         return thing
 
-    def find(self, query={}, page=1, page_size=50):
+    def find(self, query={}, page=1, page_size=50,
+             paginate_if_longer_than=10000):
+
         total = self.things.find(query).count()
-        pages = math.ceil(total/page_size)
+        if total < paginate_if_longer_than:
+            page_size = total
+            pages = 0
+        else:
+            pages = math.ceil(total/page_size)
         if page == 1:
             start = page - 1
         else:


### PR DESCRIPTION
For smaller datasets, we would like to show the entire
dataset on the register page, rather than paginated
data. This lets us offer nice client-side sorting
and filtering on the dataset, giving the user a better
sense of the data.

Check the length of the dataset, and set pages to 0
if the dataset is under 10k rows. This is a configurable
option.